### PR TITLE
redefine clf in predict endpoint

### DIFF
--- a/C2 - Agile Development with Azure/project/starter_files/flask-sklearn/app.py
+++ b/C2 - Agile Development with Azure/project/starter_files/flask-sklearn/app.py
@@ -60,6 +60,7 @@ def predict():
     inference_payload = pd.DataFrame(json_payload)
     LOG.info(f"inference payload DataFrame: {inference_payload}")
     scaled_payload = scale(inference_payload)
+    clf = joblib.load("boston_housing_prediction.joblib")
     prediction = list(clf.predict(scaled_payload))
     return jsonify({'prediction': prediction})
 


### PR DESCRIPTION
When the clf is defined out of the scope of the predict endpoint, we are unable to run with et predictions by starting the app with flask run command